### PR TITLE
Fix typos and incorrect filepath

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,16 +543,16 @@ $ mv drupal newsite.dev
 ```
 $ cd newsite.dev/sites
 ```
-5. For Pantheon.io sites, copy example.settings.local.php to /default and name it settings.local.php
+5. For Pantheon.io sites, copy example.settings.local.php to default and name it settings.local.php
 
 ```Bash
 $ cp example.settings.local.php default/settings.local.php
 ```
 
-6. Change to the /default directory. Copy default.settings.php and rename as settings.php
+6. Change to the default directory. Copy default.settings.php and rename as settings.php
     
 ```Bash
-$ cd /default
+$ cd default
 ```
 ```Bash
 $ cp default.settings.php settings.php


### PR DESCRIPTION
Whats fixed: Fixed typos on steps 5 and 6 under database creation. Also fixed incorrect filepath on step 6.

Explanation:
In step 5, your bash has you copy over everything into your default folder in newsite.dev/sites, but you referenced /default in your text. In step 6, if you try to cp into /default, you get an error stating that /default doesn't exist, since the default directory was never created in root in any previous steps.